### PR TITLE
use dataset-rs to load hits data

### DIFF
--- a/reload/hits.sh
+++ b/reload/hits.sh
@@ -121,7 +121,7 @@ cat <<SQL | bendsql
 SQL
 
 cat <<SQL | bendsql
-COPY INTO hits FROM 's3://repo.databend.rs/hits_p/' credentials=(aws_key_id='$AWS_KEY_ID' aws_secret_key='$AWS_SECRET_KEY') pattern ='.*[.]tsv' file_format=(type='TSV' field_delimiter='\\t' record_delimiter='\\n' skip_header=1);
+COPY INTO hits FROM 'https://datasets.databend.rs/hits_100m_obfuscated_v1.tsv.xz' FILE_FORMAT = (type = TSV compression = XZ field_delimiter = '\t'  record_delimiter = '\n' skip_header = 0);
 SQL
 
 cat <<SQL | bendsql


### PR DESCRIPTION
we have a public data set url which used for users to evaluate databend.

but after migrated to R2, the loading performance degraded a lot.

this PR switch to the public data set url to check whether there is any regression on the loading performance.